### PR TITLE
Pin flask to 1.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-flask
+flask==1.1.4
 requests


### PR DESCRIPTION
The current version of `@vercel/python` depends on [Werkzeug](https://pypi.org/project/Werkzeug/#history) 1.0 but Flask 2.0 depends on Werkzeug 2.0

Pinning to Flask 1 will work